### PR TITLE
Updated default block definitions to match blocks in Gutenberg V 4.1.1

### DIFF
--- a/gutenberg-manager.php
+++ b/gutenberg-manager.php
@@ -36,6 +36,9 @@ function gm_check_gutenberg() {
 define( 'GM_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GM_URL', plugin_dir_url( __FILE__ ) );
 
+// DEFAULT BLOCK DEFINTIONS
+require_once( GM_DIR.'inc/blocks.php' );
+
 // API/HOOKS
 require_once( GM_DIR.'inc/hooks.php' );
 

--- a/inc/default-blocks.php
+++ b/inc/default-blocks.php
@@ -12,87 +12,30 @@ $wp_root = explode( 'wp-content', dirname(__FILE__) );
 $wp_root = $wp_root[0];
 require_once( $wp_root . 'wp-load.php' );
 
+define( 'GM_DIR', plugin_dir_path( __FILE__ ) );
 
-// Default Blocks Array
-$default_blocks = array(
-
-    array( 'slug' => 'core/image', 'opt' => 'gm-block-image-disable', 'title' => 'Image', 'const' => 'GM_DISABLE_BLOCK_image' ),
-    array( 'slug' => 'core/gallery', 'opt' => 'gm-block-gallery-disable', 'title' => 'Gallery', 'const' => 'GM_DISABLE_BLOCK_gallery' ),
-    array( 'slug' => 'core/heading', 'opt' => 'gm-block-heading-disable', 'title' => 'Heading', 'const' => 'GM_DISABLE_BLOCK_heading' ),
-    array( 'slug' => 'core/quote', 'opt' => 'gm-block-quote-disable', 'title' => 'Quote', 'const' => 'GM_DISABLE_BLOCK_quote' ),
-    array( 'slug' => 'core/list', 'opt' => 'gm-block-list-disable', 'title' => 'List', 'const' => 'GM_DISABLE_BLOCK_list' ),
-    array( 'slug' => 'core/cover-image', 'opt' => 'gm-block-cover-image-disable', 'title' => 'Cover Image', 'const' => 'GM_DISABLE_BLOCK_cover_image' ),
-    array( 'slug' => 'core/video', 'opt' => 'gm-block-video-disable', 'title' => 'Video', 'const' => 'GM_DISABLE_BLOCK_video' ),
-    array( 'slug' => 'core/audio', 'opt' => 'gm-block-audio-disable', 'title' => 'Audio', 'const' => 'GM_DISABLE_BLOCK_audio' ),
-    array( 'slug' => 'core/paragraph', 'opt' => 'gm-block-paragraph-disable', 'title' => 'Paragraph', 'const' => 'GM_DISABLE_BLOCK_paragraph' ),
-    array( 'slug' => 'core/subhead', 'opt' => 'gm-block-subhead-disable', 'title' => 'Subhead', 'const' => 'GM_DISABLE_BLOCK_subhead' ),
-    array( 'slug' => 'core/pullquote', 'opt' => 'gm-block-pullquote-disable', 'title' => 'Pullquote', 'const' => 'GM_DISABLE_BLOCK_pullquote' ),
-    array( 'slug' => 'core/table', 'opt' => 'gm-block-table-disable', 'title' => 'Table', 'const' => 'GM_DISABLE_BLOCK_table' ),
-    array( 'slug' => 'core/preformatted', 'opt' => 'gm-block-preformatted-disable', 'title' => 'Preformatted', 'const' => 'GM_DISABLE_BLOCK_preformatted' ),
-    array( 'slug' => 'core/code', 'opt' => 'gm-block-code-disable', 'title' => 'Code', 'const' => 'GM_DISABLE_BLOCK_code' ),
-    array( 'slug' => 'core/html', 'opt' => 'gm-block-html-disable', 'title' => 'Custom HTML', 'const' => 'GM_DISABLE_BLOCK_custom_html' ),
-    array( 'slug' => 'core/freeform', 'opt' => 'gm-block-freeform-disable', 'title' => 'Classic Text', 'const' => 'GM_DISABLE_BLOCK_classic_text' ),
-    array( 'slug' => 'core/verse', 'opt' => 'gm-block-verse-disable', 'title' => 'Verse', 'const' => 'GM_DISABLE_BLOCK_verse' ),
-    array( 'slug' => 'core/separator', 'opt' => 'gm-block-separator-disable', 'title' => 'Separator', 'const' => 'GM_DISABLE_BLOCK_separator' ),
-    array( 'slug' => 'core/more', 'opt' => 'gm-block-more-disable', 'title' => 'More', 'const' => 'GM_DISABLE_BLOCK_more' ),
-    array( 'slug' => 'core/button', 'opt' => 'gm-block-button-disable', 'title' => 'Button', 'const' => 'GM_DISABLE_BLOCK_button' ),
-    array( 'slug' => 'core/text-columns', 'opt' => 'gm-block-text-columns-disable', 'title' => 'Text Columns', 'const' => 'GM_DISABLE_BLOCK_text_columns' ),
-    array( 'slug' => 'core/shortcode', 'opt' => 'gm-block-shortcode-disable', 'title' => 'Shortcode', 'const' => 'GM_DISABLE_BLOCK_shortcode' ),
-    array( 'slug' => 'core/latest-posts', 'opt' => 'gm-block-latest-posts-disable', 'title' => 'Latest Posts', 'const' => 'GM_DISABLE_BLOCK_latest_posts' ),
-    array( 'slug' => 'core/categories', 'opt' => 'gm-block-categories-disable', 'title' => 'Categories', 'const' => 'GM_DISABLE_BLOCK_categories' ),
-    array( 'slug' => 'core/embed', 'opt' => 'gm-block-embed-disable', 'title' => 'Embed', 'const' => 'GM_DISABLE_BLOCK_embed' ),
-    array( 'slug' => 'core-embed/twitter', 'opt' => 'gm-block-twitter-disable', 'title' => 'Twitter', 'const' => 'GM_DISABLE_BLOCK_twitter' ),
-    array( 'slug' => 'core-embed/youtube', 'opt' => 'gm-block-youtube-disable', 'title' => 'YouTube', 'const' => 'GM_DISABLE_BLOCK_youtube' ),
-    array( 'slug' => 'core-embed/facebook', 'opt' => 'gm-block-facebook-disable', 'title' => 'Facebook', 'const' => 'GM_DISABLE_BLOCK_facebook' ),
-    array( 'slug' => 'core-embed/instagram', 'opt' => 'gm-block-instagram-disable', 'title' => 'Instagram', 'const' => 'GM_DISABLE_BLOCK_instagram' ),
-    array( 'slug' => 'core-embed/wordpress', 'opt' => 'gm-block-wordpress-disable', 'title' => 'WordPress', 'const' => 'GM_DISABLE_BLOCK_wordpress' ),
-    array( 'slug' => 'core-embed/soundcloud', 'opt' => 'gm-block-soundcloud-disable', 'title' => 'SoundCloud', 'const' => 'GM_DISABLE_BLOCK_soundcloud' ),
-    array( 'slug' => 'core-embed/spotify', 'opt' => 'gm-block-spotify-disable', 'title' => 'Spotify', 'const' => 'GM_DISABLE_BLOCK_spotify' ),
-    array( 'slug' => 'core-embed/flickr', 'opt' => 'gm-block-flickr-disable', 'title' => 'Flickr', 'const' => 'GM_DISABLE_BLOCK_flickr' ),
-    array( 'slug' => 'core-embed/vimeo', 'opt' => 'gm-block-vimeo-disable', 'title' => 'Vimeo', 'const' => 'GM_DISABLE_BLOCK_vimeo' ),
-    array( 'slug' => 'core-embed/animoto', 'opt' => 'gm-block-animoto-disable', 'title' => 'Animoto', 'const' => 'GM_DISABLE_BLOCK_animoto' ),
-    array( 'slug' => 'core-embed/cloudup', 'opt' => 'gm-block-cloudup-disable', 'title' => 'Cloudup', 'const' => 'GM_DISABLE_BLOCK_cloudup' ),
-    array( 'slug' => 'core-embed/collegehumor', 'opt' => 'gm-block-collegehumor-disable', 'title' => 'CollegeHumor', 'const' => 'GM_DISABLE_BLOCK_collegehumor' ),
-    array( 'slug' => 'core-embed/dailymotion', 'opt' => 'gm-block-dailymotion-disable', 'title' => 'Dailymotion', 'const' => 'GM_DISABLE_BLOCK_dailymotion' ),
-    array( 'slug' => 'core-embed/funnyordie', 'opt' => 'gm-block-funnyordie-disable', 'title' => 'Funny or Die', 'const' => 'GM_DISABLE_BLOCK_funny_or_die' ),
-    array( 'slug' => 'core-embed/hulu', 'opt' => 'gm-block-hulu-disable', 'title' => 'Hulu', 'const' => 'GM_DISABLE_BLOCK_hulu' ),
-    array( 'slug' => 'core-embed/imgur', 'opt' => 'gm-block-imgur-disable', 'title' => 'Imgur', 'const' => 'GM_DISABLE_BLOCK_imgur' ),
-    array( 'slug' => 'core-embed/issuu', 'opt' => 'gm-block-issuu-disable', 'title' => 'Issuu', 'const' => 'GM_DISABLE_BLOCK_issuu' ),
-    array( 'slug' => 'core-embed/kickstarter', 'opt' => 'gm-block-kickstarter-disable', 'title' => 'Kickstarter', 'const' => 'GM_DISABLE_BLOCK_kickstarter' ),
-    array( 'slug' => 'core-embed/meetup-com', 'opt' => 'gm-block-meetup-com-disable', 'title' => 'Meetup.com', 'const' => 'GM_DISABLE_BLOCK_meetup' ),
-    array( 'slug' => 'core-embed/mixcloud', 'opt' => 'gm-block-mixcloud-disable', 'title' => 'Mixcloud', 'const' => 'GM_DISABLE_BLOCK_mixcloud' ),
-    array( 'slug' => 'core-embed/photobucket', 'opt' => 'gm-block-photobucket-disable', 'title' => 'Photobucket', 'const' => 'GM_DISABLE_BLOCK_photobucket' ),
-    array( 'slug' => 'core-embed/polldaddy', 'opt' => 'gm-block-polldaddy-disable', 'title' => 'Polldaddy', 'const' => 'GM_DISABLE_BLOCK_polldaddy' ),
-    array( 'slug' => 'core-embed/reddit', 'opt' => 'gm-block-reddit-disable', 'title' => 'Reddit', 'const' => 'GM_DISABLE_BLOCK_reddit' ),
-    array( 'slug' => 'core-embed/reverbnation', 'opt' => 'gm-block-reverbnation-disable', 'title' => 'ReverbNation', 'const' => 'GM_DISABLE_BLOCK_reverbnation' ),
-    array( 'slug' => 'core-embed/screencast', 'opt' => 'gm-block-screencast-disable', 'title' => 'Screencast', 'const' => 'GM_DISABLE_BLOCK_screencast' ),
-    array( 'slug' => 'core-embed/scribd', 'opt' => 'gm-block-scribd-disable', 'title' => 'Scribd', 'const' => 'GM_DISABLE_BLOCK_scribd' ),
-    array( 'slug' => 'core-embed/slideshare', 'opt' => 'gm-block-slideshare-disable', 'title' => 'Slideshare', 'const' => 'GM_DISABLE_BLOCK_slideshare' ),
-    array( 'slug' => 'core-embed/smugmug', 'opt' => 'gm-block-smugmug-disable', 'title' => 'SmugMug', 'const' => 'GM_DISABLE_BLOCK_smugmug' ),
-    array( 'slug' => 'core-embed/speaker', 'opt' => 'gm-block-speaker-disable', 'title' => 'Speaker', 'const' => 'GM_DISABLE_BLOCK_speaker' ),
-    array( 'slug' => 'core-embed/ted', 'opt' => 'gm-block-ted-disable', 'title' => 'TED', 'const' => 'GM_DISABLE_BLOCK_ted' ),
-    array( 'slug' => 'core-embed/tumblr', 'opt' => 'gm-block-tumblr-disable', 'title' => 'Tumblr', 'const' => 'GM_DISABLE_BLOCK_tumblr' ),
-    array( 'slug' => 'core-embed/videopress', 'opt' => 'gm-block-videopress-disable', 'title' => 'VideoPress', 'const' => 'GM_DISABLE_BLOCK_videopress' ),
-    array( 'slug' => 'core-embed/wordpress-tv', 'opt' => 'gm-block-wordpress-tv-disable', 'title' => 'WordPress.tv', 'const' => 'GM_DISABLE_BLOCK_wordpress_tv' ),
-
-);
-
+// DEFAULT BLOCK DEFINTIONS
+require_once( GM_DIR.'inc/blocks.php' );
 
 echo "window.onload = function() {";
 
 // Removal Loop
-foreach( $default_blocks as $block ){
 
-    if( get_option($block['opt']) ){
+foreach( $gm_default_blocks as $cat=>$blocks ){
+    foreach( $blocks as $block ){
+        
+        if( get_option($block['opt']) ){
 
-        echo "wp.blocks.unregisterBlockType( '".$block['slug']."' );\n";
+            echo "wp.blocks.unregisterBlockType( '".$block['slug']."' );\n";
 
-    }
+        }
 
-    if( defined($block['const']) && constant($block['const']) ){
+        if( defined($block['const']) && constant($block['const']) ){
 
-        echo "wp.blocks.unregisterBlockType( '".$block['slug']."' );\n";
+            echo "wp.blocks.unregisterBlockType( '".$block['slug']."' );\n";
 
+        }
+        
     }
 
 }

--- a/inc/options.php
+++ b/inc/options.php
@@ -18,8 +18,10 @@ function add_gutenberg_manager_menu(){
 }
 
 //Options Page
-function gutenberg_manager_page(){ ?>
+function gutenberg_manager_page(){ 
+    global $gm_default_blocks;
 
+    ?>
     <div class="wrap">
 
         <h2><?php esc_html_e('Gutenberg Manager', 'gutenberg-manager'); ?></h2>
@@ -53,82 +55,7 @@ function gutenberg_manager_page(){ ?>
         $post_types = get_post_types(array('public' => true, '_builtin' => false), 'object');
 
         // Default Blocks Array
-        $default_blocks = array(
-
-            'Common' => array(
-                array( 'slug' => 'core/image', 'name' => 'image', 'title' => 'Image' ),
-                array( 'slug' => 'core/gallery', 'name' => 'gallery', 'title' => 'Gallery' ),
-                array( 'slug' => 'core/heading', 'name' => 'heading', 'title' => 'Heading' ),
-                array( 'slug' => 'core/quote', 'name' => 'quote', 'title' => 'Quote' ),
-                array( 'slug' => 'core/list', 'name' => 'list', 'title' => 'List' ),
-                array( 'slug' => 'core/cover-image', 'name' => 'cover-image', 'title' => 'Cover Image' ),
-                array( 'slug' => 'core/video', 'name' => 'video', 'title' => 'Video' ),
-                array( 'slug' => 'core/audio', 'name' => 'audio', 'title' => 'Audio' ),
-                array( 'slug' => 'core/paragraph', 'name' => 'paragraph', 'title' => 'Paragraph' ),
-                array( 'slug' => 'core/subhead', 'name' => 'subhead', 'title' => 'Subhead' ),
-            ),
-
-            'Formatting' => array(
-                array( 'slug' => 'core/pullquote', 'name' => 'pullquote', 'title' => 'Pullquote' ),
-                array( 'slug' => 'core/table', 'name' => 'table', 'title' => 'Table' ),
-                array( 'slug' => 'core/preformatted', 'name' => 'preformatted', 'title' => 'Preformatted' ),
-                array( 'slug' => 'core/code', 'name' => 'code', 'title' => 'Code' ),
-                array( 'slug' => 'core/html', 'name' => 'html', 'title' => 'Custom HTML' ),
-                array( 'slug' => 'core/freeform', 'name' => 'freeform', 'title' => 'Classic Text' ),
-                array( 'slug' => 'core/verse', 'name' => 'verse', 'title' => 'Verse' ),
-            ),
-
-            'Layout' => array(
-                array( 'slug' => 'core/separator', 'name' => 'separator', 'title' => 'Separator' ),
-                array( 'slug' => 'core/more', 'name' => 'more', 'title' => 'More' ),
-                array( 'slug' => 'core/button', 'name' => 'button', 'title' => 'Button' ),
-                array( 'slug' => 'core/text-columns', 'name' => 'text-columns', 'title' => 'Text Columns' ),
-            ),
-
-            'Widgets' => array(
-                array( 'slug' => 'core/shortcode', 'name' => 'shortcode', 'title' => 'Shortcode' ),
-                array( 'slug' => 'core/latest-posts', 'name' => 'latest-posts', 'title' => 'Latest Posts' ),
-                array( 'slug' => 'core/categories', 'name' => 'categories', 'title' => 'Categories' ),
-            ),
-
-            'Embed' => array(
-                array( 'slug' => 'core/embed', 'name' => 'embed', 'title' => 'Embed' ),
-                array( 'slug' => 'core-embed/twitter', 'name' => 'twitter', 'title' => 'Twitter' ),
-                array( 'slug' => 'core-embed/youtube', 'name' => 'youtube', 'title' => 'YouTube' ),
-                array( 'slug' => 'core-embed/facebook', 'name' => 'facebook', 'title' => 'Facebook' ),
-                array( 'slug' => 'core-embed/instagram', 'name' => 'instagram', 'title' => 'Instagram' ),
-                array( 'slug' => 'core-embed/wordpress', 'name' => 'wordpress', 'title' => 'WordPress' ),
-                array( 'slug' => 'core-embed/soundcloud', 'name' => 'soundcloud', 'title' => 'SoundCloud' ),
-                array( 'slug' => 'core-embed/spotify', 'name' => 'spotify', 'title' => 'Spotify' ),
-                array( 'slug' => 'core-embed/flickr', 'name' => 'flickr', 'title' => 'Flickr' ),
-                array( 'slug' => 'core-embed/vimeo', 'name' => 'vimeo', 'title' => 'Vimeo' ),
-                array( 'slug' => 'core-embed/animoto', 'name' => 'animoto', 'title' => 'Animoto' ),
-                array( 'slug' => 'core-embed/cloudup', 'name' => 'cloudup', 'title' => 'Cloudup' ),
-                array( 'slug' => 'core-embed/collegehumor', 'name' => 'collegehumor', 'title' => 'CollegeHumor' ),
-                array( 'slug' => 'core-embed/dailymotion', 'name' => 'dailymotion', 'title' => 'Dailymotion' ),
-                array( 'slug' => 'core-embed/funnyordie', 'name' => 'funnyordie', 'title' => 'Funny or Die' ),
-                array( 'slug' => 'core-embed/hulu', 'name' => 'hulu', 'title' => 'Hulu' ),
-                array( 'slug' => 'core-embed/imgur', 'name' => 'imgur', 'title' => 'Imgur' ),
-                array( 'slug' => 'core-embed/issuu', 'name' => 'issuu', 'title' => 'Issuu' ),
-                array( 'slug' => 'core-embed/kickstarter', 'name' => 'kickstarter', 'title' => 'Kickstarter' ),
-                array( 'slug' => 'core-embed/meetup-com', 'name' => 'meetup-com', 'title' => 'Meetup.com' ),
-                array( 'slug' => 'core-embed/mixcloud', 'name' => 'mixcloud', 'title' => 'Mixcloud' ),
-                array( 'slug' => 'core-embed/photobucket', 'name' => 'photobucket', 'title' => 'Photobucket' ),
-                array( 'slug' => 'core-embed/polldaddy', 'name' => 'polldaddy', 'title' => 'Polldaddy' ),
-                array( 'slug' => 'core-embed/reddit', 'name' => 'reddit', 'title' => 'Reddit' ),
-                array( 'slug' => 'core-embed/reverbnation', 'name' => 'reverbnation', 'title' => 'ReverbNation' ),
-                array( 'slug' => 'core-embed/screencast', 'name' => 'screencast', 'title' => 'Screencast' ),
-                array( 'slug' => 'core-embed/scribd', 'name' => 'scribd', 'title' => 'Scribd' ),
-                array( 'slug' => 'core-embed/slideshare', 'name' => 'slideshare', 'title' => 'Slideshare' ),
-                array( 'slug' => 'core-embed/smugmug', 'name' => 'smugmug', 'title' => 'SmugMug' ),
-                array( 'slug' => 'core-embed/speaker', 'name' => 'speaker', 'title' => 'Speaker' ),
-                array( 'slug' => 'core-embed/ted', 'name' => 'ted', 'title' => 'TED' ),
-                array( 'slug' => 'core-embed/tumblr', 'name' => 'tumblr', 'title' => 'Tumblr' ),
-                array( 'slug' => 'core-embed/videopress', 'name' => 'videopress', 'title' => 'VideoPress' ),
-                array( 'slug' => 'core-embed/wordpress-tv', 'name' => 'wordpress-tv', 'title' => 'WordPress.tv' ),
-            ),
-
-        );
+        
 
         // Options names list
         $opt_names_list = '';
@@ -292,8 +219,9 @@ function gutenberg_manager_page(){ ?>
                     <?php if( $active_tab == 'default-blocks' ) { ?>
 
                         <?php
+                        
                         // Default Blocks Opt Names
-                        foreach( $default_blocks as $cat=>$blocks ){
+                        foreach( $gm_default_blocks as $cat=>$blocks ){
                             foreach( $blocks as $block ){
                                 $opt_names_list .= 'gm-block-'.$block['name'].'-disable,';
                             }
@@ -304,7 +232,7 @@ function gutenberg_manager_page(){ ?>
                             <p><?php esc_html_e('Here you can disable the default blocks in the Editor.', 'gutenberg-manager'); ?></p>
                         </div>
 
-                        <?php foreach( $default_blocks as $cat=>$blocks ) { ?>
+                        <?php foreach( $gm_default_blocks as $cat=>$blocks ) { ?>
 
                             <?php
                             // Icons
@@ -531,66 +459,14 @@ function your_default_blocks_managing(){
                                 <h4><?php esc_html_e('Blocks names', 'gutenberg-manager'); ?></h4>
 
 <pre class="language-php"><code class="language-php">
-
 array(
-    'image' // Image
-    'gallery' // Gallery
-    'heading' // Heading
-    'quote' // Quote
-    'list' // List
-    'cover_image' // Cover Image
-    'video' // Video
-    'audio' // Audio
-    'paragraph' // Paragraph
-    'subhead' // Subhead
-    'pullquote' // Pullquote
-    'table' // Table
-    'preformatted' // Preformatted
-    'code' // Code
-    'custom_html' // Custom HTML
-    'classic_text' // Classic Text
-    'verse' // Verse
-    'separator' // Separator
-    'more' // More
-    'button' // Button
-    'text_columns' // Text Columns
-    'shortcode' // Shortcode
-    'latest_posts' // Latest Posts
-    'categories' // Categories
-    'embed' // Embed
-    'twitter' // Twitter
-    'youtube' // YouTube
-    'facebook' // Facebook
-    'instagram' // Instagram
-    'wordpress' // WordPress
-    'soundcloud' // SoundCloud
-    'spotify' // Spotify
-    'flickr' // Flickr
-    'vimeo' // Vimeo
-    'animoto' // Animoto
-    'cloudup' // Cloudup
-    'collegehumor' // CollegeHumor
-    'dailymotion' // Dailymotion
-    'funny_or_die' // Funny or Die
-    'hulu' // Hulu
-    'imgur' // Imgur
-    'issuu' // Issuu
-    'kickstarter' // Kickstarter
-    'meetup' // Meetup.com
-    'mixcloud' // Mixcloud
-    'photobucket' // Photobucket
-    'polldaddy' // Polldaddy
-    'reddit' // Reddit
-    'reverbnation' // ReverbNation
-    'screencast' // Screencast
-    'scribd' // Scribd
-    'slideshare' // Slideshare
-    'smugmug' // SmugMug
-    'speaker' // Speaker
-    'ted' // TED
-    'tumblr' // Tumblr
-    'videopress' // VideoPress
-    'wordpress_tv' // WordPress.tv
+<?php 
+        foreach( $gm_default_blocks as $cat=>$blocks ){
+            foreach( $blocks as $block ){
+                echo "    '" . $block['name'] . "', //" . $block['title'] . "\n";
+            }
+        }
+?>
 )
 
 </code></pre>


### PR DESCRIPTION
Hello, thanks for creating the plugin it's very useful. Unfortunately the Gutenberg project has moved on and made substantial changes to the available default blocks. The following code matches to the currently available blocks. To make adjustments easier, I've brought the definitions into one place.

Thanks!